### PR TITLE
Added LDAPs support, now runs as nonprivileged user

### DIFF
--- a/PasswordChangeOptions.cs
+++ b/PasswordChangeOptions.cs
@@ -1,0 +1,18 @@
+﻿namespace Unosquare.PassCore.PasswordProvider
+{
+    using System.Collections.Generic;
+
+    public class PasswordChangeOptions
+    {
+        public bool UseAutomaticContext { get; set; } = true;
+        public int LdapPort { get; set; } = 389;
+        public string LdapHostname { get; set; }
+        public string LdapSearchbase { get; set; }
+        public string LdapPassword { get; set; }
+        public string LdapUsername { get; set; }
+        public List<string> RestrictedADGroups { get; set; }
+        public bool CheckRestrictedAdGroups { get; set; }
+        public List<string> AllowedADGroups { get; set; }
+        public bool CheckAllowedAdGroups { get; set; }
+    }
+}

--- a/PasswordChangeProvider.cs
+++ b/PasswordChangeProvider.cs
@@ -1,0 +1,157 @@
+﻿namespace Unosquare.PassCore.PasswordProvider
+{
+    using System.DirectoryServices.AccountManagement;
+    using System;
+    using Microsoft.Extensions.Options;
+    using System.Linq;
+    using Common;
+
+    public partial class PasswordChangeProvider : IPasswordChangeProvider
+    {
+        private readonly PasswordChangeOptions  _options;
+
+        public PasswordChangeProvider(IOptions<PasswordChangeOptions> options)
+        {
+            _options = options.Value;
+        }
+
+        public ApiErrorItem PerformPasswordChange(string username, string currentPassword, string newPassword)
+        {
+            // perform the password change
+            try
+            {
+                using (var principalContext = AcquirePrincipalContext())
+                {
+                    var userPrincipal = UserPrincipal.FindByIdentity(principalContext, username);
+
+                    // Check if the user principal exists
+                    if (userPrincipal == null)
+                    {
+                        return new ApiErrorItem { ErrorCode = ApiErrorCode.UserNotFound };
+                    }
+
+                    // Check if password change is allowed
+                    if (userPrincipal.UserCannotChangePassword)
+                    {
+                        return new ApiErrorItem { ErrorCode = ApiErrorCode.ChangeNotPermitted };
+                    }
+
+                    // Verify user is not a member of an excluded group
+                    if (_options.CheckRestrictedAdGroups)
+                    {
+                    //    foreach (var userPrincipalAuthGroup in userPrincipal.GetAuthorizationGroups())
+                    //    {
+                    //        if (_options.RestrictedADGroups.Contains(userPrincipalAuthGroup.Name))
+                    //        {
+                    //            return new ApiErrorItem { ErrorCode = ApiErrorCode.ChangeNotPermitted };
+                    //        }
+                    //    }
+						foreach (var _optionsrestrictedgroup in _options.RestrictedADGroups)
+						{
+							GroupPrincipal resgroup = GroupPrincipal.FindByIdentity(principalContext, _optionsrestrictedgroup);
+							if (userPrincipal.IsMemberOf(resgroup))
+							{
+								return new ApiErrorItem { ErrorCode = ApiErrorCode.ChangeNotPermitted };
+							}
+						}
+                    }
+
+                    if (_options.CheckAllowedAdGroups)
+                    {
+                    //    foreach (var userPrincipalAuthGroup in userPrincipal.GetAuthorizationGroups())
+                    //   {
+                    //        if (!_options.AllowedADGroups.Contains(userPrincipalAuthGroup.Name))
+                    //        {
+                    //            return new ApiErrorItem { ErrorCode = ApiErrorCode.ChangeNotPermitted };
+                    //        }
+                    //    }
+					bool memberofallowedgroup = false;
+                        foreach (var _optionsallowedgroup in _options.AllowedADGroups)
+                        {
+                            GroupPrincipal allowgroup = GroupPrincipal.FindByIdentity(principalContext, _optionsallowedgroup);
+                            if (userPrincipal.IsMemberOf(allowgroup))
+                            {
+                                memberofallowedgroup = true;
+                                break;
+                            }
+                            
+                        }
+                        if (memberofallowedgroup != true)
+                        {
+                            return new ApiErrorItem { ErrorCode = ApiErrorCode.ChangeNotPermitted };
+                        }
+                    }
+
+                    // Validate user credentials
+                    if (principalContext.ValidateCredentials(username, currentPassword) == false)
+                    {
+                        if (!LogonUser(username, username.Split('@').Last(), currentPassword, LogonTypes.Network, LogonProviders.Default, out _))
+                        {
+                            var errorCode = System.Runtime.InteropServices.Marshal.GetLastWin32Error();
+                            switch (errorCode)
+                            {
+                                case ERROR_PASSWORD_MUST_CHANGE:
+                                case ERROR_PASSWORD_EXPIRED:
+                                    // Both of these means that the password CAN change and that we got the correct password
+                                    break;
+                                default:
+                                    return new ApiErrorItem { ErrorCode = ApiErrorCode.InvalidCredentials };
+                            }
+                        }
+                    }
+
+                    // Change the password via 2 different methods. Try SetPassword if ChangePassword fails.
+                    try
+                    {
+                        // Try by regular ChangePassword method
+                        userPrincipal.ChangePassword(currentPassword,newPassword);
+                    }
+                    catch
+                    {
+                        if (_options.UseAutomaticContext) { throw; }
+
+                        // If the previous attempt failed, use the SetPassword method.
+                        userPrincipal.SetPassword(newPassword);
+                    }
+
+                    userPrincipal.Save();
+                }
+            }
+            catch (Exception ex)
+            {
+                return new ApiErrorItem { ErrorCode = ApiErrorCode.Generic, Message = ex.Message };
+            }
+
+            return null;
+        }
+
+        private PrincipalContext AcquirePrincipalContext()
+        {
+            PrincipalContext principalContext;
+            if (_options.UseAutomaticContext)
+            {
+				//  principalContext = new PrincipalContext(ContextType.Domain);
+                ContextOptions options = ContextOptions.Negotiate | ContextOptions.ServerBind| ContextOptions.SecureSocketLayer;
+                principalContext = new PrincipalContext(
+                    ContextType.Domain,
+                    null,
+                    $"{_options.LdapSearchbase}",
+                    options,
+                    _options.LdapUsername,
+                    _options.LdapPassword
+                    );
+			}
+            else
+            {
+                principalContext = new PrincipalContext(
+                    ContextType.Domain,
+                    $"{_options.LdapHostname}:{_options.LdapPort}",
+                    $"{_options.LdapSearchbase}",
+                    _options.LdapUsername,
+                    _options.LdapPassword);
+            }
+
+            return principalContext;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ PassCore has the following features:
 1. Ensure the server running IIS is domain-joined. To determine if the computer is domain-joined:
     - Go to the *Start* menu, right click on *Computer*, then select *Properties*
     - Make sure the *Domain* field contains the correct setting.
-1. You need a Passcore copy to continue. We recommed to download the latest binary release of [PassCore](https://github.com/unosquare/passcore/releases/download/3.2.1/PassCore321.zip).
+1. You need a Passcore copy to continue. We recommed to download the latest binary release of [PassCore](https://github.com/unosquare/passcore/releases/download/3.2.0/PassCore320.zip).
 1. **NOTE:** Before extracting the contents of the file, please right click on it, select Properties and make sure the file is Unblocked (Click on the Unblock button at the bottom of the dialog if it is available). Then, extract the contents of the zip file to the directory where you will be serving the website from.
     - If you download the source code you need to run the following command via an Command Prompt. Make sure you start the Command Prompt with the Administrator option.
     - `dotnet publish --configuration Release --runtime win-x64 --output "<path>"`
     - The `<path>` is the directory where you will be serving the website from.
-1. Install the [.NET Core 2.1 Windows Server Hosting bundle](https://www.microsoft.com/net/download/thank-you/dotnet-runtime-2.1.0-windows-hosting-bundle-installer).
+1. Install the [.NET Core Windows Server Hosting bundle](https://docs.microsoft.com/en-us/aspnet/core/publishing/iis?tabs=aspnetcore2x#install-the-net-core-windows-server-hosting-bundle). You will need at least [.NET Core Runtime 2.1.0 / SDK 2.1.300](https://www.microsoft.com/net/download/windows).
 1. Go to your *IIS Manager*, Right click on *Application Pools* and select *Add Application Pool*.
 1. A dialog appears. Under Name enter **PassCore Application Pool**, Under .NET CLR Version select **No Managed Code** and finally, under Managed pipeline mode select **Integrated**. Click OK after all fields have been set.
 1. Now, right click on the application pool you just created in the previous step and select *Advanced Settings ...*. Change the *Start Mode* to **AlwaysRunning**, and the *Idle Time-out (minutes)* to **0**. Click on *OK*. This will ensure PassCore stays responsive even after long periods of inactivity.
@@ -78,6 +78,7 @@ The most relevant configuration entries are shown below. Make sure you make your
   1. Find the `CheckRestrictedAdGroups` entry and set it to `true` (without quotes)
   2. Find the `RestrictedADGroups` entry and add any groups that are sensitive.  Accounts in these groups (directly or inherited) will not be able to change their password.
 - Find the `DefaultDomain` entry and set it to your default Active Directory domain. This should eliminate confusion about using e-mail domains / internal domain names.
+- Fill the `LdapSearchbase` parameter with something like "DC=...,DC=yourdomain,DC=yourcountry"
 - To provide an optional paramerter to the URL to set the username text box automatically
   1. `http://mypasscore.com/?userName=someusername`
   2. This helps the user incase they forgot thier username and, also comes in handy when sending a link to the application or having it embeded into another application were the user is all ready signed in.

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,0 +1,76 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  },
+  "PasswordChangeOptions": {
+    "UseAutomaticContext": true,
+    "LdapHostname": "",
+    "LdapPort": 389,
+    "LdapSearchBase": "",
+    "LdapUsername": "",
+    "LdapPassword": "",
+    "CheckRestrictedAdGroups": true,
+    "RestrictedADGroups": [
+      "Administrators",
+      "Domain Admins",
+      "Enterprise Admins"
+    ],
+    "CheckAllowedAdGroups": false,
+    "AllowedADGroups": [ ]
+  },
+  "AppSettings": {
+    "EnableHttpsRedirect": false,
+    "RecaptchaPrivateKey": "", // ReCAPTCHA private key: replace this!
+    "ClientSettings": {
+      "ValidationRegex": {
+        "EmailRegex": "^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$",
+        "UsernameRegex": "^[a-zA-Z0-9._-]{3,20}$"
+      },
+      "ShowPasswordMeter": true,
+      "Recaptcha": {
+        "IsEnabled": true,
+        "SiteKey": "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI", // ReCAPTCHA public key: replace this!
+        "LanguageCode": "en"
+      },
+      "ApplicationTitle": "Self-Service Account Management Tools",
+      "ChangePasswordTitle": "Change Account Password",
+      "ChangePasswordForm": {
+        "HelpTitle": "Help and Support",
+        "HelpText": "If you are having trouble with this tool, please contact IT Support",
+        "UsernameLabel": "Username",
+        "UsernameHelpblock": "Your organization's email address",
+        "UsernameDefaultDomainHelperBlock": "Your organization's username",
+        "CurrentPasswordLabel": "Current Password",
+        "CurrentPasswordHelpblock": "Enter your current password",
+        "NewPasswordLabel": "New Password",
+        "NewPasswordHelpblock": "Enter a <a href='https://support.microsoft.com/en-us/help/4026406/microsoft-account-create-a-strong-password' target='_blank'>strong password</a>. You can use <a href='https://xkpasswd.net/s/' target='_blank'>this tool</a> to help you create one; use the XKCD (random sep, pad digit), or NTLM, options.",
+        "NewPasswordVerifyLabel": "Re-enter New Password",
+        "NewPasswordVerifyHelpblock": "Enter your new password again",
+        "ChangePasswordButtonLabel": "Change Password"
+      },
+      "ErrorsPasswordForm": {
+        "FieldRequired": "This field is required",
+        "UsernamePattern": "Please enter a valid username",
+        "UsernameEmailPattern": "Please enter a valid email address",
+        "PasswordMatch": "Passwords do not match"
+      },
+      "DefaultDomain": "domain.com", // Set your default AD domain here, or non "@" logins will not work!
+      "Alerts": {
+        "SuccessAlertTitle": "You have changed your password successfully.",
+        "SuccessAlertBody": "Please note it may take a few hours for your new password to reach all domain controllers.",
+        "ErrorPasswordChangeNotAllowed": "You are not allowed to change your password. Please contact your system administrator.",
+        "ErrorInvalidCredentials": "You need to provide the correct current password.",
+        "ErrorInvalidDomain": "You have supplied an invalid domain to logon to.",
+        "ErrorInvalidUser": "We could not find your user account.",
+        "ErrorCaptcha": "Could not verify you are not a robot",
+        "ErrorFieldRequired": "Fulfil all the fields",
+        "ErrorFieldMismatch": "The passwords do not match"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Bugfix: Using nonprivileged user when running passcore failed to change password because this requires connect to LDAP with Port 636 (LDAPS) or "signed and sealed" when using Port 389 - added necessary options in principalContext
Added option LDAP-Searchbase, which is necessary when connecting with LDAPS in appsettings.json and added comment in Readme.md

Bugfix: Using CheckRestrictedAdGroups- and CheckallowedGroups-feature failed with error "The specified directory service attribute or value does not exist" - changed the function to get the group[s] configured in appsettings.json and call a 'ismemberof' instead the other way. (Tracings shows, that GetGroups() and GetAuthorizationGroups() throws an exception error on AD Builtin domain groups